### PR TITLE
chore: increase disk size

### DIFF
--- a/authnz/main.go
+++ b/authnz/main.go
@@ -95,7 +95,7 @@ func main() {
 				InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
 					Image: pulumi.String("debian-12-bookworm-v20240515"),
 					Type:  pulumi.String("pd-standard"),
-					Size:  pulumi.Int(10),
+					Size:  pulumi.Int(30),
 				},
 				AutoDelete: pulumi.Bool(false),
 			},

--- a/rollout/main.go
+++ b/rollout/main.go
@@ -93,7 +93,7 @@ func main() {
 				InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
 					Image: pulumi.String("debian-12-bookworm-v20240515"),
 					Type:  pulumi.String("pd-standard"),
-					Size:  pulumi.Int(10),
+					Size:  pulumi.Int(30),
 				},
 				AutoDelete: pulumi.Bool(false),
 			},


### PR DESCRIPTION
- `authnz` ran out of disk space

disk usage is high:

<img width="470" alt="image" src="https://github.com/nmathew98/shared-resources/assets/55116576/75e60e23-a708-4cc5-bfb4-e5a6bf1eed1a">

<img width="471" alt="image" src="https://github.com/nmathew98/shared-resources/assets/55116576/2738cd50-7cdf-4eab-a920-27cd9cf94bf4">
