### PR TITLE
Revert "chore: change discovery type to single node"

### DIFF
--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       node.name: telemetry_elasticsearch.{{.Task.Slot}}
       path.data: ./data/elasticsearch.{{.Task.Slot}}
       discovery.seed_hosts: tasks.elasticsearch
-      discovery.type: single-node
       # cluster.initial_master_nodes: telemetry_elasticsearch.1,telemetry_elasticsearch.2,telemetry_elasticsearch.3
       ELASTIC_USERNAME: ${ELASTIC_USERNAME}
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}


### PR DESCRIPTION
Reverts nmathew98/shared-resources#118

cluster is locked in

<img width="1437" alt="image" src="https://github.com/nmathew98/shared-resources/assets/55116576/a061c40b-5b39-4eba-a508-a1ecec3965f8">
