### PR TITLE
chore: zero downtime deployment

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -275,17 +275,6 @@ jobs:
           passphrase: ${{ secrets.GCP_SSH_PASSPHRASE }}
           port: 22
           script: |
-            sudo su
-
-            # TODO: before, updated env wasn't being applied when just updating a stack like this
-            # TODO: if we refer to a node specifically by ip, there are issues with nginx not being able
-            # to resolve the hostname because it caches
-            docker stack rm ${{ env.STACK_NAME }}
-            docker system prune -af
-
-            sleep 30s
-
-            docker pull ${{ env.KRYPTOS }}
             export $(docker run --rm --env-file ${{ env.ENV_FILE }} ${{ env.KRYPTOS }} cat | xargs)
             
             if [[ "${{ env.BRANCH_NAME }}" != "master" ]]; then
@@ -294,8 +283,10 @@ jobs:
 
             cd shared-resources-${{ env.BRANCH_NAME }}/${{ matrix.service }}
 
-            docker stack deploy --compose-file ${{ env.SERVICES_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }}
+            docker stack deploy --compose-file ${{ env.SERVICES_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }} --detach=false
             sleep 30s
-            docker stack deploy --compose-file ${{ env.LOGS_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }}
+            docker stack deploy --compose-file ${{ env.LOGS_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }} --detach=false
             sleep 30s
-            docker stack deploy --compose-file ${{ env.PROXY_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }}
+            docker stack deploy --compose-file ${{ env.PROXY_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }} --detach=false
+            sleep 30s
+            docker system prune -af

--- a/authnz/docker-compose.proxy.yml
+++ b/authnz/docker-compose.proxy.yml
@@ -12,7 +12,7 @@ services:
         published: 443
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     secrets:
@@ -24,8 +24,8 @@ services:
       - keycloak
     ulimits:
       nofile:
-        soft: 15000
-        hard: 15000
+        soft: 20000
+        hard: 20000
 
 networks:
   keycloak:

--- a/authnz/docker-compose.yml
+++ b/authnz/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     command: "start --optimized --proxy-headers xforwarded"
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
       endpoint_mode: dnsrr
 
   logstash:
@@ -54,17 +54,10 @@ services:
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
       LS_JAVA_OPTS: "-Xmx${LOGSTASH_HEAP} -Xms${LOGSTASH_HEAP} -Dlog4j2.formatMsgNoLookups=true"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-s",
-          "-XGET",
-          "http://127.0.0.1:9600"
-        ]
+      test: [ "CMD", "curl", "-s", "-XGET", "http://127.0.0.1:9600" ]
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
 
   filebeat:
     image: docker.elastic.co/beats/filebeat:${ELK_VERSION}
@@ -84,16 +77,9 @@ services:
       - filebeat-data:/var/lib/filebeat/data
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]
 
   heartbeat:
     image: docker.elastic.co/beats/heartbeat:${ELK_VERSION}
@@ -106,7 +92,7 @@ services:
     command: -e --strict.perms=false
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     environment:
       ELASTIC_USERNAME: ${ELASTIC_USERNAME}
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
@@ -114,14 +100,7 @@ services:
       KEYCLOAK_PUBLIC_HOST: ${KC_HOSTNAME}
       JAVA_ENV: ${JAVA_ENV}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]
 
   metricbeat:
     image: docker.elastic.co/beats/metricbeat:${ELK_VERSION}
@@ -136,17 +115,10 @@ services:
       - metricbeat-data:/var/lib/metricbeat/data
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     environment:
       ELASTIC_USERNAME: ${ELASTIC_USERNAME}
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]

--- a/authnz/nginx/nginx.conf
+++ b/authnz/nginx/nginx.conf
@@ -10,7 +10,7 @@ http {
     ip_hash;
     
     server keycloak.1:8080;
-    # server keycloak.2:8080;
+    server keycloak.2:8080;
     # server keycloak.3:8080;
   }
 

--- a/rollout/docker-compose.proxy.yml
+++ b/rollout/docker-compose.proxy.yml
@@ -12,7 +12,7 @@ services:
         published: 443
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     secrets:
@@ -24,8 +24,8 @@ services:
       - flipt
     ulimits:
       nofile:
-        soft: 15000
-        hard: 15000
+        soft: 20000
+        hard: 20000
 
 networks:
   flipt:

--- a/rollout/docker-compose.yml
+++ b/rollout/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${GO_ENV},deployment.node={{.Task.Slot}}"
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
 
   logstash:
     image: docker.elastic.co/logstash/logstash:${ELK_VERSION}
@@ -63,17 +63,10 @@ services:
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
       LS_JAVA_OPTS: "-Xmx${LOGSTASH_HEAP} -Xms${LOGSTASH_HEAP} -Dlog4j2.formatMsgNoLookups=true"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-s",
-          "-XGET",
-          "http://127.0.0.1:9600"
-        ]
+      test: [ "CMD", "curl", "-s", "-XGET", "http://127.0.0.1:9600" ]
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
 
   filebeat:
     image: docker.elastic.co/beats/filebeat:${ELK_VERSION}
@@ -93,16 +86,9 @@ services:
       - filebeat-data:/var/lib/filebeat/data
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]
 
   heartbeat:
     image: docker.elastic.co/beats/heartbeat:${ELK_VERSION}
@@ -121,16 +107,9 @@ services:
       GO_ENV: ${GO_ENV}
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]
 
   metricbeat:
     image: docker.elastic.co/beats/metricbeat:${ELK_VERSION}
@@ -149,13 +128,6 @@ services:
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]

--- a/telemetry/docker-compose.logs.yml
+++ b/telemetry/docker-compose.logs.yml
@@ -25,16 +25,9 @@ services:
       - elastic
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "localhost:5066/?pretty"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "localhost:5066/?pretty" ]
 
 networks:
   elastic:

--- a/telemetry/docker-compose.proxy.yml
+++ b/telemetry/docker-compose.proxy.yml
@@ -16,7 +16,7 @@ services:
         published: 2083
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     secrets:
@@ -28,8 +28,8 @@ services:
       - elastic
     ulimits:
       nofile:
-        soft: 15000
-        hard: 15000
+        soft: 20000
+        hard: 20000
 
 networks:
   elastic:

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -72,13 +72,7 @@ services:
         soft: 200000
         hard: 200000
     healthcheck:
-      test:
-        [
-          "CMD",
-          "sh",
-          "-c",
-          "curl -sf --insecure https://$ELASTIC_USERNAME:$ELASTIC_PASSWORD@localhost:$ELASTICSEARCH_PORT/_cat/health | grep -ioE 'green|yellow' || echo 'not green/yellow cluster status'"
-        ]
+      test: [ "CMD", "sh", "-c", "curl -sf --insecure https://$ELASTIC_USERNAME:$ELASTIC_PASSWORD@localhost:$ELASTICSEARCH_PORT/_cat/health | grep -ioE 'green|yellow' || echo 'not green/yellow cluster status'" ]
     deploy:
       mode: replicated
       replicas: 3
@@ -99,19 +93,12 @@ services:
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
       LS_JAVA_OPTS: "-Xmx${LOGSTASH_HEAP} -Xms${LOGSTASH_HEAP} -Dlog4j2.formatMsgNoLookups=true"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-sf",
-          "-XGET",
-          "http://127.0.0.1:9600"
-        ]
+      test: [ "CMD", "curl", "-sf", "-XGET", "http://127.0.0.1:9600" ]
     depends_on:
       - elasticsearch
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 0 # 1
 
   kibana:
     image: skulpture/kibana:${TAG:-latest}
@@ -135,19 +122,11 @@ services:
         target: /certs/kibana.key
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
     depends_on:
       - elasticsearch
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "--insecure",
-          "-sf",
-          "-XGET",
-          "https://127.0.0.1:5601"
-        ]
+      test: [ "CMD", "curl", "--insecure", "-sf", "-XGET", "https://127.0.0.1:5601" ]
 
   apm-server:
     image: skulpture/apm-server:${TAG:-latest}
@@ -168,6 +147,6 @@ services:
         target: /certs/apm-server.key
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 2
     depends_on:
       - elasticsearch


### PR DESCRIPTION
- Nginx should be redeployed: https://stackoverflow.com/a/67270270
- docker stack deploy should also be using latest envs: https://stackoverflow.com/a/65796391
- last time didn't work, checking if it'll work now
- disabled elastic beats for everything because its lower priority, keycloak and flipt have open telemetry which should be fine for the moment