### PR TITLE
chore: update nginx config for authnz to rely on persistent user sessions

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -288,10 +288,5 @@ jobs:
             docker stack deploy --compose-file ${{ env.LOGS_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }} --detach=false
             sleep 30s
             docker stack deploy --compose-file ${{ env.PROXY_DOCKER_COMPOSE_FILE }} ${{ env.STACK_NAME }} --detach=false
-            # proxy has to be redeployed in the case of authnz because we are not going through swarm dns
-            # and referring to the node directly for sticky sessions. without sticky sessions, if the user reloads
-            # the page, then they will have to login again if they get a different node. swarm does not redeploy a
-            # service unless the image sha has changed
-            docker service update --force ${{ env.STACK_NAME }}_proxy
             sleep 30s
             docker system prune -af

--- a/authnz/nginx/nginx.conf
+++ b/authnz/nginx/nginx.conf
@@ -6,9 +6,7 @@ http {
   error_log /dev/stdout;
   access_log off;
 
-  upstream keycloak {
-    ip_hash;
-    
+  upstream keycloak {    
     server keycloak:8080;
   }
 

--- a/authnz/nginx/nginx.conf
+++ b/authnz/nginx/nginx.conf
@@ -9,9 +9,7 @@ http {
   upstream keycloak {
     ip_hash;
     
-    server keycloak.1:8080;
-    server keycloak.2:8080;
-    # server keycloak.3:8080;
+    server keycloak:8080;
   }
 
   server {


### PR DESCRIPTION
see: https://www.keycloak.org/2024/06/persistent-user-sessions-in-preview

- tried previously but didn't work then
- requests to keycloak will go through docker internal dns so we don't have to force the proxy to update if it doesn't need to