### PR TITLE
chore: update kc healthcheck

### DIFF
--- a/authnz/docker-compose.yml
+++ b/authnz/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${JAVA_ENV},deployment.node={{.Task.Slot}}"
     command: "start --optimized --proxy-headers xforwarded"
     healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080 || exit 1" ]
+      test: [ "CMD-SHELL", "wget -O - http://localhost:8080 &>/dev/null || exit 1" ]
       interval: 1m30s
       timeout: 30s
       retries: 5

--- a/telemetry/apm-server/Dockerfile
+++ b/telemetry/apm-server/Dockerfile
@@ -5,5 +5,5 @@ FROM docker.elastic.co/apm/apm-server:${ELK_VERSION}
 ARG ELK_VERSION
 
 USER root
-RUN apt update && apt install curl
+RUN apt update && apt install -y curl
 USER apm-server

--- a/telemetry/apm-server/Dockerfile
+++ b/telemetry/apm-server/Dockerfile
@@ -3,3 +3,5 @@ ARG ELK_VERSION
 # https://github.com/elastic/apm-server
 FROM docker.elastic.co/apm/apm-server:${ELK_VERSION}
 ARG ELK_VERSION
+
+RUN apt update && apt install curl

--- a/telemetry/apm-server/Dockerfile
+++ b/telemetry/apm-server/Dockerfile
@@ -4,4 +4,6 @@ ARG ELK_VERSION
 FROM docker.elastic.co/apm/apm-server:${ELK_VERSION}
 ARG ELK_VERSION
 
+USER root
 RUN apt update && apt install curl
+USER apm-server

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -163,6 +163,12 @@ services:
     deploy:
       mode: replicated
       replicas: 2
+    healthcheck:
+      test: [ "CMD", "curl", "--insecure", "-sf", "-XGET", "https://127.0.0.1:8200" ]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 1m
     depends_on:
       - elasticsearch
 

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -163,12 +163,6 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-    healthcheck:
-      test: [ "CMD", "curl", "--insecure", "-sf", "-XGET", "https://127.0.0.1:8200" ]
-      interval: 1m30s
-      timeout: 30s
-      retries: 5
-      start_period: 1m
     depends_on:
       - elasticsearch
 


### PR DESCRIPTION
https://unix.stackexchange.com/questions/513749/wget-spider-fails-with-404-but-works-without-spider

good for zero downtime deploys, only 1 node running:

<img width="979" alt="image" src="https://github.com/user-attachments/assets/eb6ee6e2-100e-4d22-afa7-796549032625">

<img width="1519" alt="image" src="https://github.com/user-attachments/assets/7f8cb8c4-a5e7-4f5e-a94c-489bb1e32a71">
