### PR TITLE
chore: update endpoint mode for frontend services

### DIFF
--- a/authnz/docker-compose.yml
+++ b/authnz/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-      endpoint_mode: dnsrr
+      endpoint_mode: vip
 
   logstash:
     image: docker.elastic.co/logstash/logstash:${ELK_VERSION}

--- a/rollout/docker-compose.yml
+++ b/rollout/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
+      endpoint_mode: vip
     healthcheck:
       test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080 || exit 1" ]
       interval: 1m30s

--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -134,6 +134,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
+      endpoint_mode: vip
     depends_on:
       - elasticsearch
     healthcheck:


### PR DESCRIPTION
issue: #279 

https://forums.docker.com/t/understanding-vips-with-overlay-networks-in-swarm-mode/134254/2

https://docs.docker.com/reference/compose-file/deploy/#endpoint_mode

<img width="774" alt="image" src="https://github.com/user-attachments/assets/02040091-1816-4a3a-8627-e318868369f5">

service ip should remain stable and nginx will be able to query the same ips