### PR TITLE
chore: size up authnz

### DIFF
--- a/authnz/main.go
+++ b/authnz/main.go
@@ -44,7 +44,7 @@ func main() {
 
 		instance, err := compute.NewInstance(ctx, COMPUTE_INSTANCE_NAME.Value(), &compute.InstanceArgs{
 			Name:        pulumi.String(COMPUTE_INSTANCE_NAME.Value()),
-			MachineType: pulumi.String("e2-micro"), // pulumi.String("e2-small"),
+			MachineType: pulumi.String("e2-small"),
 			Zone:        pulumi.String("australia-southeast1-a"),
 			Tags: pulumi.ToStringArray([]string{
 				"allow-cloudflare",

--- a/rollout/main.go
+++ b/rollout/main.go
@@ -44,7 +44,7 @@ func main() {
 
 		instance, err := compute.NewInstance(ctx, COMPUTE_INSTANCE_NAME.Value(), &compute.InstanceArgs{
 			Name:        pulumi.String(COMPUTE_INSTANCE_NAME.Value()),
-			MachineType: pulumi.String("e2-small"),
+			MachineType: pulumi.String("e2-micro"),
 			Zone:        pulumi.String("australia-southeast1-a"),
 			Tags: pulumi.ToStringArray([]string{
 				"allow-cloudflare",

--- a/rollout/main.go
+++ b/rollout/main.go
@@ -44,7 +44,7 @@ func main() {
 
 		instance, err := compute.NewInstance(ctx, COMPUTE_INSTANCE_NAME.Value(), &compute.InstanceArgs{
 			Name:        pulumi.String(COMPUTE_INSTANCE_NAME.Value()),
-			MachineType: pulumi.String("e2-micro") // pulumi.String("e2-medium"),
+			MachineType: pulumi.String("e2-small"),
 			Zone:        pulumi.String("australia-southeast1-a"),
 			Tags: pulumi.ToStringArray([]string{
 				"allow-cloudflare",


### PR DESCRIPTION
- `e2-micro` is too small, instance will hang
- think should be fine for rollout since golang but java is too heavy
- thought since its a quarkus image might be fine