### PR TITLE
chore: update traefik config to disable internal ssl cert verification

### DIFF
--- a/telemetry/docker-compose.yml
+++ b/telemetry/docker-compose.yml
@@ -49,7 +49,6 @@ services:
     command: >
       --providers.swarm.endpoint=unix:///var/run/docker.sock
       --providers.swarm.exposedByDefault=false
-      --providers.swarm.tls.insecureSkipVerify=true
       --providers.file.directory=/traefik
       --providers.file.watch=true
       --entryPoints.web.address=:80
@@ -57,6 +56,8 @@ services:
       --entryPoints.websecure.asDefault=true
       --entryPoints.web.http.redirections.entryPoint.to=websecure
       --entryPoints.web.http.redirections.entryPoint.scheme=https
+      --tcpServersTransport.tls.insecureSkipVerify=true
+      --serversTransport.insecureSkipVerify=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./traefik:/traefik


### PR DESCRIPTION
we have self signed certs for elastic because it needs them to run in prod mode

`providers.swarm.tls.insecureSkipVerify` is for the connection to docker swarm itself not to upstream services

also see:
- https://doc.traefik.io/traefik/routing/overview/#insecureskipverify
- https://doc.traefik.io/traefik/routing/overview/#tlsinsecureskipverify