### PR TITLE
chore: fix sticky cookie for authnz

### DIFF
--- a/authnz/docker-compose.yml
+++ b/authnz/docker-compose.yml
@@ -90,6 +90,7 @@ services:
         traefik.http.services.authnz-service.loadbalancer.healthcheck.path: /health/ready
         traefik.http.services.authnz-service.loadbalancer.healthcheck.status: 200
         traefik.http.services.authnz-service.loadbalancer.healthcheck.port: 9000
-        # https://www.keycloak.org/server/reverseproxy#_enable_sticky_sessions
-        traefik.http.services.authnz-service.loadbalancer.sticky.cookie.name: "AUTH_SESSION_ID"
+        traefik.http.services.authnz-service.loadbalancer.sticky.cookie.secure: "true"
+        traefik.http.services.authnz-service.loadbalancer.sticky.cookie.httpOnly: "true"
+        traefik.http.services.authnz-service.loadbalancer.sticky.cookie.domain: authnz.skulpture.xyz        
         traefik.swarm.lbswarm: "false"


### PR DESCRIPTION
#515 

traefik adds another value instead of using the existing value:

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/b4dce142-9b48-4f22-a30e-b28cacc548e9" />
