### PR TITLE
fix: prevent "0" display below login button when no social providers

### DIFF
--- a/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
@@ -97,7 +97,7 @@ export const Login = (
 			}
 			socialProvidersNode={
 				<>
-					{realm.password && social?.providers?.length && (
+					{realm.password && social?.providers?.length > 0 && (
 						<>
 							<div className="flex flex-col items-center gap-4 w-full">
 								<H4>{msg("identity-provider-login-label")}</H4>

--- a/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
@@ -103,11 +103,11 @@ export const Login = (
 								<H4>{msg("identity-provider-login-label")}</H4>
 								<div
 									className={
-										social.providers.length < 3
+										(social?.providers?.length ?? 0) < 3
 											? "flex flex-col gap-4 w-full"
 											: "grid grid-flow-row md:grid-cols-3 w-full gap-4"
 									}>
-									{social.providers.map(provider => {
+									{social?.providers?.map(provider => {
 										const Logo =
 											SSO_PROVIDERS_ICONS[
 												provider.providerId as keyof typeof SSO_PROVIDERS_ICONS

--- a/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
@@ -97,7 +97,7 @@ export const Login = (
 			}
 			socialProvidersNode={
 				<>
-					{realm.password && Number(social?.providers?.length) > 0 && (
+					{realm.password && social?.providers && Number(social?.providers?.length) > 0 && (
 						<>
 							<div className="flex flex-col items-center gap-4 w-full">
 								<H4>{msg("identity-provider-login-label")}</H4>

--- a/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/Login.tsx
@@ -97,17 +97,17 @@ export const Login = (
 			}
 			socialProvidersNode={
 				<>
-					{realm.password && social?.providers?.length > 0 && (
+					{realm.password && Number(social?.providers?.length) > 0 && (
 						<>
 							<div className="flex flex-col items-center gap-4 w-full">
 								<H4>{msg("identity-provider-login-label")}</H4>
 								<div
 									className={
-										(social?.providers?.length ?? 0) < 3
+										social.providers.length < 3
 											? "flex flex-col gap-4 w-full"
 											: "grid grid-flow-row md:grid-cols-3 w-full gap-4"
 									}>
-									{social?.providers?.map(provider => {
+									{social.providers.map(provider => {
 										const Logo =
 											SSO_PROVIDERS_ICONS[
 												provider.providerId as keyof typeof SSO_PROVIDERS_ICONS


### PR DESCRIPTION
Fixed conditional rendering in socialProvidersNode prop by changing
social?.providers?.length to social?.providers?.length > 0 to avoid
React rendering 0 when there are no social providers.

Fixes #615

Generated with [Claude Code](https://claude.ai/code)