### PR TITLE
feat: add custom register, update-email and idp-review-user-profile pages

### DIFF
--- a/authnz-theme/README.md
+++ b/authnz-theme/README.md
@@ -4,4 +4,4 @@ Custom Keycloak theme
 
 Related resources:
 
--   https://docs.keycloakify.dev
+- https://docs.keycloakify.dev

--- a/authnz-theme/src/keycloak-theme/login/KcPage.tsx
+++ b/authnz-theme/src/keycloak-theme/login/KcPage.tsx
@@ -20,8 +20,15 @@ import { LoginResetPassword } from "./pages/LoginResetPassword";
 import { LoginUsername } from "./pages/LoginUsername";
 import { LoginVerifyEmail } from "./pages/LoginVerifyEmail";
 import { LoginRecoveryAuthnCodeConfig } from "./pages/LoginRecoveryAuthnCodeConfig";
+import { Register } from "./pages/Register";
+import { UpdateEmail } from "./pages/UpdateEmail";
+import { IdpReviewUserProfile } from "./pages/IdpReviewUserProfile";
 
-const UserProfileFormFields = lazy(() => import("./UserProfileFormFields"));
+const UserProfileFormFields = lazy(() =>
+	import("./UserProfileFormFields").then(({ UserProfileFormFields }) => ({
+		default: UserProfileFormFields,
+	})),
+);
 
 const doMakeUserConfirmPassword = true;
 
@@ -207,6 +214,51 @@ export default function KcPage(props: { kcContext: KcContext }) {
 								classes={classes}
 								Template={Template}
 								doUseDefaultCss={false}
+							/>
+						);
+					}
+					case "register.ftl": {
+						return (
+							<Register
+								kcContext={kcContext}
+								i18n={i18n}
+								classes={classes}
+								Template={Template}
+								doUseDefaultCss={false}
+								UserProfileFormFields={UserProfileFormFields}
+								doMakeUserConfirmPassword={
+									doMakeUserConfirmPassword
+								}
+							/>
+						);
+					}
+					case "update-email.ftl": {
+						return (
+							<UpdateEmail
+								kcContext={kcContext}
+								i18n={i18n}
+								classes={classes}
+								Template={Template}
+								doUseDefaultCss={false}
+								UserProfileFormFields={UserProfileFormFields}
+								doMakeUserConfirmPassword={
+									doMakeUserConfirmPassword
+								}
+							/>
+						);
+					}
+					case "idp-review-user-profile.ftl": {
+						return (
+							<IdpReviewUserProfile
+								kcContext={kcContext}
+								i18n={i18n}
+								classes={classes}
+								Template={Template}
+								doUseDefaultCss={false}
+								UserProfileFormFields={UserProfileFormFields}
+								doMakeUserConfirmPassword={
+									doMakeUserConfirmPassword
+								}
 							/>
 						);
 					}

--- a/authnz-theme/src/keycloak-theme/login/UserProfileFormFields.tsx
+++ b/authnz-theme/src/keycloak-theme/login/UserProfileFormFields.tsx
@@ -11,10 +11,34 @@ import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFo
 import type { Attribute } from "keycloakify/login/KcContext";
 import type { KcContext } from "./KcContext";
 import type { I18n } from "./i18n";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { FormGroup } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Small } from "@/components/typography";
+import { cn } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
 
-export default function UserProfileFormFields(
+const nativeInputClassName =
+	"flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+
+const invalidInputClassName = "border-red-500 focus-visible:ring-red-500";
+
+const hiddenFields = new Set(["locale"]);
+
+const fieldOrder = [
+	"firstName",
+	"lastName",
+	"username",
+	"email",
+	"password",
+	"password-confirm",
+];
+
+export const UserProfileFormFields = (
 	props: UserProfileFormFieldsProps<KcContext, I18n>,
-) {
+) => {
 	const {
 		kcContext,
 		i18n,
@@ -42,10 +66,26 @@ export default function UserProfileFormFields(
 	}, [isFormSubmittable]);
 
 	const groupNameRef = { current: "" };
+	const visibleFormFieldStates = formFieldStates
+		.filter(
+			formFieldState => !hiddenFields.has(formFieldState.attribute.name),
+		)
+		.sort((a, b) => {
+			const PRESERVE_ORDER = 0;
+
+			const aIdx = fieldOrder.findIndex(x => a.attribute.name === x);
+			const bIdx = fieldOrder.findIndex(x => b.attribute.name === x);
+
+			if (~aIdx && ~bIdx) {
+				return aIdx - bIdx;
+			}
+
+			return PRESERVE_ORDER;
+		});
 
 	return (
-		<>
-			{formFieldStates.map(
+		<div className="flex w-full flex-col gap-6">
+			{visibleFormFieldStates.map(
 				({ attribute, displayableErrors, valueOrValues }) => {
 					return (
 						<Fragment key={attribute.name}>
@@ -65,8 +105,8 @@ export default function UserProfileFormFields(
 									i18n={i18n}
 								/>
 							)}
-							<div
-								className={kcClsx("kcFormGroupClass")}
+							<FormGroup
+								className="!flex w-full !flex-col !gap-2"
 								style={{
 									display:
 										attribute.name === "password-confirm" &&
@@ -74,95 +114,80 @@ export default function UserProfileFormFields(
 											? "none"
 											: undefined,
 								}}>
-								<div className={kcClsx("kcLabelWrapperClass")}>
-									<label
-										htmlFor={attribute.name}
-										className={kcClsx("kcLabelClass")}>
+								<div className="flex items-center gap-1 leading-none">
+									<Label htmlFor={attribute.name}>
 										{advancedMsg(
 											attribute.displayName ?? "",
 										)}
-									</label>
-									{attribute.required && <>*</>}
+									</Label>
 								</div>
-								<div className={kcClsx("kcInputWrapperClass")}>
-									{attribute.annotations
-										.inputHelperTextBefore !==
-										undefined && (
-										<div
-											className={kcClsx(
-												"kcInputHelperTextBeforeClass",
-											)}
-											id={`form-help-text-before-${attribute.name}`}
-											aria-live="polite">
-											{advancedMsg(
-												attribute.annotations
-													.inputHelperTextBefore,
-											)}
-										</div>
-									)}
-									<InputFiledByType
+								{attribute.annotations.inputHelperTextBefore !==
+									undefined && (
+									<Small
+										className="text-muted-foreground"
+										id={`form-help-text-before-${attribute.name}`}
+										aria-live="polite">
+										{advancedMsg(
+											attribute.annotations
+												.inputHelperTextBefore,
+										)}
+									</Small>
+								)}
+								<InputFiledByType
+									attribute={attribute}
+									valueOrValues={valueOrValues}
+									displayableErrors={displayableErrors}
+									dispatchFormAction={dispatchFormAction}
+									kcClsx={kcClsx}
+									i18n={i18n}
+								/>
+								<FieldErrors
+									attribute={attribute}
+									displayableErrors={displayableErrors}
+									fieldIndex={undefined}
+								/>
+								{attribute.annotations.inputHelperTextAfter !==
+									undefined && (
+									<Small
+										className="text-muted-foreground"
+										id={`form-help-text-after-${attribute.name}`}
+										aria-live="polite">
+										{advancedMsg(
+											attribute.annotations
+												.inputHelperTextAfter,
+										)}
+									</Small>
+								)}
+
+								{AfterField !== undefined && (
+									<AfterField
 										attribute={attribute}
-										valueOrValues={valueOrValues}
-										displayableErrors={displayableErrors}
 										dispatchFormAction={dispatchFormAction}
+										displayableErrors={displayableErrors}
+										valueOrValues={valueOrValues}
 										kcClsx={kcClsx}
 										i18n={i18n}
 									/>
-									<FieldErrors
-										attribute={attribute}
-										displayableErrors={displayableErrors}
-										kcClsx={kcClsx}
-										fieldIndex={undefined}
-									/>
-									{attribute.annotations
-										.inputHelperTextAfter !== undefined && (
-										<div
-											className={kcClsx(
-												"kcInputHelperTextAfterClass",
-											)}
-											id={`form-help-text-after-${attribute.name}`}
-											aria-live="polite">
-											{advancedMsg(
-												attribute.annotations
-													.inputHelperTextAfter,
-											)}
-										</div>
-									)}
-
-									{AfterField !== undefined && (
-										<AfterField
-											attribute={attribute}
-											dispatchFormAction={
-												dispatchFormAction
-											}
-											displayableErrors={
-												displayableErrors
-											}
-											valueOrValues={valueOrValues}
-											kcClsx={kcClsx}
-											i18n={i18n}
-										/>
-									)}
-									{/* NOTE: Downloading of html5DataAnnotations scripts is done in the useUserProfileForm hook */}
-								</div>
-							</div>
+								)}
+								{/* NOTE: Downloading of html5DataAnnotations scripts is done in the useUserProfileForm hook */}
+							</FormGroup>
 						</Fragment>
 					);
 				},
 			)}
-		</>
+		</div>
 	);
-}
+};
 
-function GroupLabel(props: {
+const GroupLabel = (props: {
 	attribute: Attribute;
 	groupNameRef: {
 		current: string;
 	};
 	i18n: I18n;
 	kcClsx: KcClsx;
-}) {
-	const { attribute, groupNameRef, i18n, kcClsx } = props;
+}) => {
+	const { attribute, groupNameRef, i18n } = props;
 
 	const { advancedMsg } = i18n;
 
@@ -173,8 +198,7 @@ function GroupLabel(props: {
 			assert(attribute.group !== undefined);
 
 			return (
-				<div
-					className={kcClsx("kcFormGroupClass")}
+				<FormGroup
 					{...Object.fromEntries(
 						Object.entries(
 							attribute.group.html5DataAnnotations,
@@ -189,12 +213,12 @@ function GroupLabel(props: {
 								: attribute.group.name;
 
 						return (
-							<div className={kcClsx("kcContentWrapperClass")}>
-								<label
+							<div>
+								<Label
 									id={`header-${attribute.group.name}`}
-									className={kcClsx("kcFormGroupHeader")}>
+									className="text-base font-semibold">
 									{groupHeaderText}
-								</label>
+								</Label>
 							</div>
 						);
 					})()}
@@ -208,33 +232,32 @@ function GroupLabel(props: {
 							);
 
 							return (
-								<div className={kcClsx("kcLabelWrapperClass")}>
-									<label
+								<div>
+									<Small
 										id={`description-${attribute.group.name}`}
-										className={kcClsx("kcLabelClass")}>
+										className="text-muted-foreground">
 										{groupDescriptionText}
-									</label>
+									</Small>
 								</div>
 							);
 						}
 
 						return null;
 					})()}
-				</div>
+				</FormGroup>
 			);
 		}
 	}
 
 	return null;
-}
+};
 
-function FieldErrors(props: {
+const FieldErrors = (props: {
 	attribute: Attribute;
 	displayableErrors: FormFieldError[];
 	fieldIndex: number | undefined;
-	kcClsx: KcClsx;
-}) {
-	const { attribute, fieldIndex, kcClsx } = props;
+}) => {
+	const { attribute, fieldIndex } = props;
 
 	const displayableErrors = props.displayableErrors.filter(
 		error => error.fieldIndex === fieldIndex,
@@ -245,9 +268,9 @@ function FieldErrors(props: {
 	}
 
 	return (
-		<span
+		<Small
 			id={`input-error-${attribute.name}${fieldIndex === undefined ? "" : `-${fieldIndex}`}`}
-			className={kcClsx("kcInputErrorMessageClass")}
+			className="text-red-500"
 			aria-live="polite">
 			{displayableErrors
 				.filter(error => error.fieldIndex === fieldIndex)
@@ -257,9 +280,9 @@ function FieldErrors(props: {
 						{arr.length - 1 !== i && <br />}
 					</Fragment>
 				))}
-		</span>
+		</Small>
 	);
-}
+};
 
 type InputFiledByTypeProps = {
 	attribute: Attribute;
@@ -270,7 +293,7 @@ type InputFiledByTypeProps = {
 	kcClsx: KcClsx;
 };
 
-function InputFiledByType(props: InputFiledByTypeProps) {
+const InputFiledByType = (props: InputFiledByTypeProps) => {
 	const { attribute, valueOrValues } = props;
 
 	switch (attribute.annotations.inputType) {
@@ -301,7 +324,6 @@ function InputFiledByType(props: InputFiledByTypeProps) {
 			) {
 				return (
 					<PasswordWrapper
-						kcClsx={props.kcClsx}
 						i18n={props.i18n}
 						passwordInputId={attribute.name}>
 						{inputNode}
@@ -312,15 +334,14 @@ function InputFiledByType(props: InputFiledByTypeProps) {
 			return inputNode;
 		}
 	}
-}
+};
 
-function PasswordWrapper(props: {
-	kcClsx: KcClsx;
+const PasswordWrapper = (props: {
 	i18n: I18n;
 	passwordInputId: string;
 	children: React.JSX.Element;
-}) {
-	const { kcClsx, i18n, passwordInputId, children } = props;
+}) => {
+	const { i18n, passwordInputId, children } = props;
 
 	const { msgStr } = i18n;
 
@@ -338,37 +359,43 @@ function PasswordWrapper(props: {
 		/* eslint-disable react-hooks/exhaustive-deps */
 	}, [isPasswordRevealed]);
 
+	const onClickTogglePassword: React.MouseEventHandler<
+		HTMLButtonElement
+	> = event => {
+		event.preventDefault();
+
+		toggleIsPasswordRevealed();
+	};
+
 	return (
-		<div className={kcClsx("kcInputGroup")}>
-			{children}
-			<button
-				type="button"
-				className={kcClsx("kcFormPasswordVisibilityButtonClass")}
+		<div className="flex w-full items-start gap-2">
+			<div className="w-full">{children}</div>
+			<Button
+				variant="outline"
+				size="icon"
+				className="w-max"
 				aria-label={msgStr(
 					isPasswordRevealed ? "hidePassword" : "showPassword",
 				)}
 				aria-controls={passwordInputId}
-				onClick={toggleIsPasswordRevealed}>
-				<i
-					className={kcClsx(
-						isPasswordRevealed
-							? "kcFormPasswordVisibilityIconHide"
-							: "kcFormPasswordVisibilityIconShow",
-					)}
-					aria-hidden
-				/>
-			</button>
+				onClick={onClickTogglePassword}>
+				{isPasswordRevealed && (
+					<Eye aria-hidden className="h-5 m-2 w-auto" />
+				)}
+				{!isPasswordRevealed && (
+					<EyeOff aria-hidden className="h-5 m-2 w-auto" />
+				)}
+			</Button>
 		</div>
 	);
-}
+};
 
-function InputTag(
+const InputTag = (
 	props: InputFiledByTypeProps & { fieldIndex: number | undefined },
-) {
+) => {
 	const {
 		attribute,
 		fieldIndex,
-		kcClsx,
 		dispatchFormAction,
 		valueOrValues,
 		i18n,
@@ -377,9 +404,16 @@ function InputTag(
 
 	return (
 		<>
-			<input
+			<Input
 				type={(() => {
 					const { inputType } = attribute.annotations;
+
+					if (
+						attribute.name === "password" ||
+						attribute.name === "password-confirm"
+					) {
+						return "password";
+					}
 
 					if (inputType?.startsWith("html5-")) {
 						return inputType.slice(6);
@@ -389,6 +423,7 @@ function InputTag(
 				})()}
 				id={attribute.name}
 				name={attribute.name}
+				className="w-full"
 				value={(() => {
 					if (fieldIndex !== undefined) {
 						assert(valueOrValues instanceof Array);
@@ -399,8 +434,7 @@ function InputTag(
 
 					return valueOrValues;
 				})()}
-				className={kcClsx("kcInputClass")}
-				aria-invalid={
+				isError={
 					displayableErrors.find(
 						error => error.fieldIndex === fieldIndex,
 					) !== undefined
@@ -478,7 +512,6 @@ function InputTag(
 					<>
 						<FieldErrors
 							attribute={attribute}
-							kcClsx={kcClsx}
 							displayableErrors={displayableErrors}
 							fieldIndex={fieldIndex}
 						/>
@@ -494,9 +527,9 @@ function InputTag(
 			})()}
 		</>
 	);
-}
+};
 
-function AddRemoveButtonsMultiValuedAttribute(props: {
+const AddRemoveButtonsMultiValuedAttribute = (props: {
 	attribute: Attribute;
 	values: string[];
 	fieldIndex: number;
@@ -504,7 +537,7 @@ function AddRemoveButtonsMultiValuedAttribute(props: {
 		Extract<FormAction, { action: "update" }>
 	>;
 	i18n: I18n;
-}) {
+}) => {
 	const { attribute, values, fieldIndex, dispatchFormAction, i18n } = props;
 
 	const { msg } = i18n;
@@ -519,13 +552,12 @@ function AddRemoveButtonsMultiValuedAttribute(props: {
 	const idPostfix = `-${attribute.name}-${fieldIndex + 1}`;
 
 	return (
-		<>
+		<div className="flex flex-wrap gap-2">
 			{hasRemove && (
-				<>
+				<Button variant="secondary" size="sm" asChild>
 					<button
 						id={`kc-remove${idPostfix}`}
 						type="button"
-						className="pf-c-button pf-m-inline pf-m-link"
 						onClick={() =>
 							dispatchFormAction({
 								action: "update",
@@ -537,34 +569,34 @@ function AddRemoveButtonsMultiValuedAttribute(props: {
 						}>
 						{msg("remove")}
 					</button>
-					{hasAdd ? <>&nbsp;|&nbsp;</> : null}
-				</>
+				</Button>
 			)}
 			{hasAdd && (
-				<button
-					id={`kc-add${idPostfix}`}
-					type="button"
-					className="pf-c-button pf-m-inline pf-m-link"
-					onClick={() =>
-						dispatchFormAction({
-							action: "update",
-							name: attribute.name,
-							valueOrValues: [...values, ""],
-						})
-					}>
-					{msg("addValue")}
-				</button>
+				<Button variant="secondary" size="sm" asChild>
+					<button
+						id={`kc-add${idPostfix}`}
+						type="button"
+						onClick={() =>
+							dispatchFormAction({
+								action: "update",
+								name: attribute.name,
+								valueOrValues: [...values, ""],
+							})
+						}>
+						{msg("addValue")}
+					</button>
+				</Button>
 			)}
-		</>
+		</div>
 	);
-}
+};
 
-function InputTagSelects(props: InputFiledByTypeProps) {
-	const { attribute, dispatchFormAction, kcClsx, valueOrValues } = props;
+const InputTagSelects = (props: InputFiledByTypeProps) => {
+	const { attribute, dispatchFormAction, valueOrValues } = props;
 
 	const { advancedMsg } = props.i18n;
 
-	const { classDiv, classInput, classLabel, inputType } = (() => {
+	const inputType = (() => {
 		const { inputType } = attribute.annotations;
 
 		assert(
@@ -574,19 +606,9 @@ function InputTagSelects(props: InputFiledByTypeProps) {
 
 		switch (inputType) {
 			case "select-radiobuttons":
-				return {
-					inputType: "radio",
-					classDiv: kcClsx("kcInputClassRadio"),
-					classInput: kcClsx("kcInputClassRadioInput"),
-					classLabel: kcClsx("kcInputClassRadioLabel"),
-				};
+				return "radio";
 			case "multiselect-checkboxes":
-				return {
-					inputType: "checkbox",
-					classDiv: kcClsx("kcInputClassCheckbox"),
-					classInput: kcClsx("kcInputClassCheckboxInput"),
-					classLabel: kcClsx("kcInputClassCheckboxLabel"),
-				};
+				return "checkbox";
 		}
 	})();
 
@@ -617,75 +639,103 @@ function InputTagSelects(props: InputFiledByTypeProps) {
 	})();
 
 	return (
-		<>
+		<div className="flex w-full flex-col gap-2">
 			{options.map(option => (
-				<div key={option} className={classDiv}>
-					<input
-						type={inputType}
-						id={`${attribute.name}-${option}`}
-						name={attribute.name}
-						value={option}
-						className={classInput}
-						aria-invalid={props.displayableErrors.length !== 0}
-						disabled={attribute.readOnly}
-						checked={
-							valueOrValues instanceof Array
-								? valueOrValues.includes(option)
-								: valueOrValues === option
-						}
-						onChange={event =>
-							dispatchFormAction({
-								action: "update",
-								name: attribute.name,
-								valueOrValues: (() => {
-									const isChecked = event.target.checked;
+				<div key={option} className="flex items-center gap-2">
+					{inputType === "checkbox" && (
+						<Checkbox
+							id={`${attribute.name}-${option}`}
+							name={attribute.name}
+							value={option}
+							aria-invalid={props.displayableErrors.length !== 0}
+							disabled={attribute.readOnly}
+							checked={
+								valueOrValues instanceof Array
+									? valueOrValues.includes(option)
+									: valueOrValues === option
+							}
+							onCheckedChange={checked =>
+								dispatchFormAction({
+									action: "update",
+									name: attribute.name,
+									valueOrValues: (() => {
+										const isChecked = checked === true;
 
-									if (valueOrValues instanceof Array) {
-										const newValues = [...valueOrValues];
-
-										if (isChecked) {
-											newValues.push(option);
-										} else {
-											newValues.splice(
-												newValues.indexOf(option),
-												1,
-											);
+										if (valueOrValues instanceof Array) {
+											if (isChecked) {
+												return valueOrValues.includes(
+													option,
+												)
+													? valueOrValues
+													: [
+															...valueOrValues,
+															option,
+														];
+											} else {
+												return valueOrValues.filter(
+													value => value !== option,
+												);
+											}
 										}
 
-										return newValues;
-									}
-
-									return event.target.checked ? option : "";
-								})(),
-							})
-						}
-						onBlur={() =>
-							dispatchFormAction({
-								action: "focus lost",
-								name: attribute.name,
-								fieldIndex: undefined,
-							})
-						}
-					/>
-					<label
+										return isChecked ? option : "";
+									})(),
+								})
+							}
+							onBlur={() =>
+								dispatchFormAction({
+									action: "focus lost",
+									name: attribute.name,
+									fieldIndex: undefined,
+								})
+							}
+						/>
+					)}
+					{inputType === "radio" && (
+						<input
+							type="radio"
+							id={`${attribute.name}-${option}`}
+							name={attribute.name}
+							value={option}
+							className="h-4 w-4 accent-primary disabled:cursor-not-allowed disabled:opacity-50"
+							aria-invalid={props.displayableErrors.length !== 0}
+							disabled={attribute.readOnly}
+							checked={valueOrValues === option}
+							onChange={event =>
+								dispatchFormAction({
+									action: "update",
+									name: attribute.name,
+									valueOrValues: event.target.checked
+										? option
+										: "",
+								})
+							}
+							onBlur={() =>
+								dispatchFormAction({
+									action: "focus lost",
+									name: attribute.name,
+									fieldIndex: undefined,
+								})
+							}
+						/>
+					)}
+					<Label
 						htmlFor={`${attribute.name}-${option}`}
-						className={`${classLabel}${attribute.readOnly ? ` ${kcClsx("kcInputClassRadioCheckboxLabelDisabled")}` : ""}`}>
+						className={cn(
+							attribute.readOnly &&
+								"cursor-not-allowed opacity-50",
+						)}>
 						{advancedMsg(option)}
-					</label>
+					</Label>
 				</div>
 			))}
-		</>
+		</div>
 	);
-}
+};
 
-function TextareaTag(props: InputFiledByTypeProps) {
-	const {
-		attribute,
-		dispatchFormAction,
-		kcClsx,
-		displayableErrors,
-		valueOrValues,
-	} = props;
+const TextareaTag = (props: InputFiledByTypeProps) => {
+	const { attribute, dispatchFormAction, displayableErrors, valueOrValues } =
+		props;
 
 	assert(typeof valueOrValues === "string");
 
@@ -695,7 +745,12 @@ function TextareaTag(props: InputFiledByTypeProps) {
 		<textarea
 			id={attribute.name}
 			name={attribute.name}
-			className={kcClsx("kcInputClass")}
+			className={cn(
+				nativeInputClassName,
+				"w-full",
+				"min-h-24 resize-y",
+				displayableErrors.length !== 0 && invalidInputClassName,
+			)}
 			aria-invalid={displayableErrors.length !== 0}
 			disabled={attribute.readOnly}
 			cols={
@@ -730,13 +785,12 @@ function TextareaTag(props: InputFiledByTypeProps) {
 			}
 		/>
 	);
-}
+};
 
-function SelectTag(props: InputFiledByTypeProps) {
+const SelectTag = (props: InputFiledByTypeProps) => {
 	const {
 		attribute,
 		dispatchFormAction,
-		kcClsx,
 		displayableErrors,
 		i18n,
 		valueOrValues,
@@ -750,7 +804,12 @@ function SelectTag(props: InputFiledByTypeProps) {
 		<select
 			id={attribute.name}
 			name={attribute.name}
-			className={kcClsx("kcInputClass")}
+			className={cn(
+				nativeInputClassName,
+				"w-full",
+				isMultiple && "h-auto min-h-24 py-2",
+				displayableErrors.length !== 0 && invalidInputClassName,
+			)}
 			aria-invalid={displayableErrors.length !== 0}
 			disabled={attribute.readOnly}
 			multiple={isMultiple}
@@ -847,4 +906,4 @@ function SelectTag(props: InputFiledByTypeProps) {
 			})()}
 		</select>
 	);
-}
+};

--- a/authnz-theme/src/keycloak-theme/login/pages/IdpReviewUserProfile.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/IdpReviewUserProfile.tsx
@@ -5,6 +5,8 @@ import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { Button } from "@/components/ui/button";
+import { Form, FormGroup } from "@/components/ui/form";
 
 type IdpReviewUserProfileProps = PageProps<
 	Extract<KcContext, { pageId: "idp-review-user-profile.ftl" }>,
@@ -16,7 +18,7 @@ type IdpReviewUserProfileProps = PageProps<
 	doMakeUserConfirmPassword: boolean;
 };
 
-export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
+export const IdpReviewUserProfile = (props: IdpReviewUserProfileProps) => {
 	const {
 		kcContext,
 		i18n,
@@ -45,11 +47,10 @@ export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
 			doUseDefaultCss={doUseDefaultCss}
 			classes={classes}
 			displayMessage={messagesPerField.exists("global")}
-			displayRequiredFields
+			displayRequiredFields={false}
 			headerNode={msg("loginIdpReviewProfileTitle")}>
-			<form
+			<Form
 				id="kc-idp-review-profile-form"
-				className={kcClsx("kcFormClass")}
 				action={url.loginAction}
 				method="post">
 				<UserProfileFormFields
@@ -59,29 +60,19 @@ export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
 					kcClsx={kcClsx}
 					doMakeUserConfirmPassword={doMakeUserConfirmPassword}
 				/>
-				<div className={kcClsx("kcFormGroupClass")}>
-					<div
-						id="kc-form-options"
-						className={kcClsx("kcFormOptionsClass")}>
-						<div className={kcClsx("kcFormOptionsWrapperClass")} />
-					</div>
-					<div
-						id="kc-form-buttons"
-						className={kcClsx("kcFormButtonsClass")}>
+				<FormGroup>
+					<Button
+						className="w-full cursor-pointer"
+						disabled={!isFomSubmittable}
+						asChild>
 						<input
-							className={kcClsx(
-								"kcButtonClass",
-								"kcButtonPrimaryClass",
-								"kcButtonBlockClass",
-								"kcButtonLargeClass",
-							)}
 							type="submit"
 							value={msgStr("doSubmit")}
 							disabled={!isFomSubmittable}
 						/>
-					</div>
-				</div>
-			</form>
+					</Button>
+				</FormGroup>
+			</Form>
 		</Template>
 	);
-}
+};

--- a/authnz-theme/src/keycloak-theme/login/pages/Register.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/Register.tsx
@@ -1,11 +1,16 @@
 import { useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
-import { getKcClsx, type KcClsx } from "keycloakify/login/lib/kcClsx";
+import { getKcClsx } from "keycloakify/login/lib/kcClsx";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
 import { kcSanitize } from "keycloakify/lib/kcSanitize";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Form, FormGroup } from "@/components/ui/form";
+import { Label } from "@/components/ui/label";
+import { Small } from "@/components/typography";
 
 type RegisterProps = PageProps<
 	Extract<KcContext, { pageId: "register.ftl" }>,
@@ -53,13 +58,13 @@ export const Register = (props: RegisterProps) => {
 			doUseDefaultCss={doUseDefaultCss}
 			classes={classes}
 			headerNode={msg("registerTitle")}
-			displayMessage={messagesPerField.exists("global")}
-			displayRequiredFields>
-			<form
+			displayRequiredFields={false}
+			displayMessage={messagesPerField.exists("global")}>
+			<Form
 				id="kc-register-form"
-				className={kcClsx("kcFormClass")}
 				action={url.registrationAction}
-				method="post">
+				method="post"
+				className="!flex !flex-col !gap-6">
 				<UserProfileFormFields
 					kcContext={kcContext}
 					i18n={i18n}
@@ -70,59 +75,44 @@ export const Register = (props: RegisterProps) => {
 				{termsAcceptanceRequired && (
 					<TermsAcceptance
 						i18n={i18n}
-						kcClsx={kcClsx}
 						messagesPerField={messagesPerField}
 						areTermsAccepted={areTermsAccepted}
 						onAreTermsAcceptedValueChange={setAreTermsAccepted}
 					/>
 				)}
 				{recaptchaRequired && (
-					<div className="form-group">
-						<div className={kcClsx("kcInputWrapperClass")}>
-							<div
-								className="g-recaptcha"
-								data-size="compact"
-								data-sitekey={recaptchaSiteKey}></div>
-						</div>
-					</div>
+					<FormGroup>
+						<div
+							className="g-recaptcha"
+							data-size="compact"
+							data-sitekey={recaptchaSiteKey}></div>
+					</FormGroup>
 				)}
-				<div className={kcClsx("kcFormGroupClass")}>
-					<div
-						id="kc-form-options"
-						className={kcClsx("kcFormOptionsClass")}>
-						<div className={kcClsx("kcFormOptionsWrapperClass")}>
-							<span>
-								<a href={url.loginUrl}>{msg("backToLogin")}</a>
-							</span>
-						</div>
-					</div>
-					<div
-						id="kc-form-buttons"
-						className={kcClsx("kcFormButtonsClass")}>
+				<FormGroup className="!gap-2">
+					<Button
+						className="w-full cursor-pointer"
+						disabled={
+							!isFormSubmittable ||
+							(termsAcceptanceRequired && !areTermsAccepted)
+						}
+						asChild>
 						<input
-							disabled={
-								!isFormSubmittable ||
-								(termsAcceptanceRequired && !areTermsAccepted)
-							}
-							className={kcClsx(
-								"kcButtonClass",
-								"kcButtonPrimaryClass",
-								"kcButtonBlockClass",
-								"kcButtonLargeClass",
-							)}
+							id="kc-register"
 							type="submit"
 							value={msgStr("doRegister")}
 						/>
-					</div>
-				</div>
-			</form>
+					</Button>
+					<Button variant="secondary" className="w-full" asChild>
+						<a href={url.loginUrl}>{msg("backToLogin")}</a>
+					</Button>
+				</FormGroup>
+			</Form>
 		</Template>
 	);
 };
 
 function TermsAcceptance(props: {
 	i18n: I18n;
-	kcClsx: KcClsx;
 	messagesPerField: Pick<
 		KcContext["messagesPerField"],
 		"existsError" | "get"
@@ -132,7 +122,6 @@ function TermsAcceptance(props: {
 }) {
 	const {
 		i18n,
-		kcClsx,
 		messagesPerField,
 		areTermsAccepted,
 		onAreTermsAcceptedValueChange,
@@ -142,50 +131,42 @@ function TermsAcceptance(props: {
 
 	return (
 		<>
-			<div className="form-group">
-				<div className={kcClsx("kcInputWrapperClass")}>
+			<FormGroup>
+				<Label className="text-base font-semibold">
 					{msg("termsTitle")}
-					<div id="kc-registration-terms-text">
-						{msg("termsText")}
-					</div>
+				</Label>
+				<div id="kc-registration-terms-text" className="text-sm">
+					{msg("termsText")}
 				</div>
-			</div>
-			<div className="form-group">
-				<div className={kcClsx("kcLabelWrapperClass")}>
-					<input
-						type="checkbox"
+			</FormGroup>
+			<FormGroup>
+				<div className="flex flex-row items-center gap-2">
+					<Checkbox
 						id="termsAccepted"
 						name="termsAccepted"
-						className={kcClsx("kcCheckboxInputClass")}
 						checked={areTermsAccepted}
-						onChange={e =>
-							onAreTermsAcceptedValueChange(e.target.checked)
+						onCheckedChange={checked =>
+							onAreTermsAcceptedValueChange(checked === true)
 						}
 						aria-invalid={messagesPerField.existsError(
 							"termsAccepted",
 						)}
 					/>
-					<label
-						htmlFor="termsAccepted"
-						className={kcClsx("kcLabelClass")}>
-						{msg("acceptTerms")}
-					</label>
+					<Label htmlFor="termsAccepted">{msg("acceptTerms")}</Label>
 				</div>
 				{messagesPerField.existsError("termsAccepted") && (
-					<div className={kcClsx("kcLabelWrapperClass")}>
-						<span
-							id="input-error-terms-accepted"
-							className={kcClsx("kcInputErrorMessageClass")}
-							aria-live="polite"
-							dangerouslySetInnerHTML={{
-								__html: kcSanitize(
-									messagesPerField.get("termsAccepted"),
-								),
-							}}
-						/>
-					</div>
+					<Small
+						id="input-error-terms-accepted"
+						className="text-red-500"
+						aria-live="polite"
+						dangerouslySetInnerHTML={{
+							__html: kcSanitize(
+								messagesPerField.get("termsAccepted"),
+							),
+						}}
+					/>
 				)}
-			</div>
+			</FormGroup>
 		</>
 	);
 }

--- a/authnz-theme/src/keycloak-theme/login/pages/UpdateEmail.tsx
+++ b/authnz-theme/src/keycloak-theme/login/pages/UpdateEmail.tsx
@@ -1,10 +1,14 @@
 import { useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
-import { getKcClsx, type KcClsx } from "keycloakify/login/lib/kcClsx";
+import { getKcClsx } from "keycloakify/login/lib/kcClsx";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Form, FormGroup } from "@/components/ui/form";
+import { Label } from "@/components/ui/label";
 
 type UpdateEmailProps = PageProps<
 	Extract<KcContext, { pageId: "update-email.ftl" }>,
@@ -16,7 +20,7 @@ type UpdateEmailProps = PageProps<
 	doMakeUserConfirmPassword: boolean;
 };
 
-export default function UpdateEmail(props: UpdateEmailProps) {
+export const UpdateEmail = (props: UpdateEmailProps) => {
 	const {
 		kcContext,
 		i18n,
@@ -45,11 +49,10 @@ export default function UpdateEmail(props: UpdateEmailProps) {
 			doUseDefaultCss={doUseDefaultCss}
 			classes={classes}
 			displayMessage={messagesPerField.exists("global")}
-			displayRequiredFields
+			displayRequiredFields={false}
 			headerNode={msg("updateEmailTitle")}>
-			<form
+			<Form
 				id="kc-update-email-form"
-				className={kcClsx("kcFormClass")}
 				action={url.loginAction}
 				method="post">
 				<UserProfileFormFields
@@ -60,70 +63,51 @@ export default function UpdateEmail(props: UpdateEmailProps) {
 					doMakeUserConfirmPassword={doMakeUserConfirmPassword}
 				/>
 
-				<div className={kcClsx("kcFormGroupClass")}>
-					<div
-						id="kc-form-options"
-						className={kcClsx("kcFormOptionsClass")}>
-						<div className={kcClsx("kcFormOptionsWrapperClass")} />
-					</div>
+				<FormGroup>
+					<LogoutOtherSessions i18n={i18n} />
 
-					<LogoutOtherSessions kcClsx={kcClsx} i18n={i18n} />
-
-					<div
-						id="kc-form-buttons"
-						className={kcClsx("kcFormButtonsClass")}>
+					<Button
+						className="w-full cursor-pointer"
+						disabled={!isFormSubmittable}
+						asChild>
 						<input
 							disabled={!isFormSubmittable}
-							className={kcClsx(
-								"kcButtonClass",
-								"kcButtonPrimaryClass",
-								isAppInitiatedAction && "kcButtonBlockClass",
-								"kcButtonLargeClass",
-							)}
 							type="submit"
 							value={msgStr("doSubmit")}
 						/>
-						{isAppInitiatedAction && (
-							<button
-								className={kcClsx(
-									"kcButtonClass",
-									"kcButtonDefaultClass",
-									"kcButtonLargeClass",
-								)}
-								type="submit"
-								name="cancel-aia"
-								value="true">
-								{msg("doCancel")}
-							</button>
-						)}
-					</div>
-				</div>
-			</form>
+					</Button>
+					{isAppInitiatedAction && (
+						<Button
+							variant="secondary"
+							className="mt-2 w-full"
+							type="submit"
+							name="cancel-aia"
+							value="true">
+							{msg("doCancel")}
+						</Button>
+					)}
+				</FormGroup>
+			</Form>
 		</Template>
 	);
-}
+};
 
-function LogoutOtherSessions(props: { kcClsx: KcClsx; i18n: I18n }) {
-	const { kcClsx, i18n } = props;
+const LogoutOtherSessions = (props: { i18n: I18n }) => {
+	const { i18n } = props;
 
 	const { msg } = i18n;
 
 	return (
-		<div id="kc-form-options" className={kcClsx("kcFormOptionsClass")}>
-			<div className={kcClsx("kcFormOptionsWrapperClass")}>
-				<div className="checkbox">
-					<label>
-						<input
-							type="checkbox"
-							id="logout-sessions"
-							name="logout-sessions"
-							value="on"
-							defaultChecked={true}
-						/>
-						{msg("logoutOtherSessions")}
-					</label>
-				</div>
-			</div>
+		<div id="kc-form-options" className="flex items-center gap-2">
+			<Checkbox
+				id="logout-sessions"
+				name="logout-sessions"
+				value="on"
+				defaultChecked={true}
+			/>
+			<Label htmlFor="logout-sessions">
+				{msg("logoutOtherSessions")}
+			</Label>
 		</div>
 	);
-}
+};


### PR DESCRIPTION
changes:
- customize default keycloak registration page. this touches the shared `UserProfileFormFields` so we've also customised other pages which depend on it: `IdpReviewUserProfile` and `UpdateEmail`

https://github.com/user-attachments/assets/549127eb-b155-4188-804f-31842f64ddb2

